### PR TITLE
Add footer with legal pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,5 +16,11 @@
         </ul>
     </p>
     <img src="https://cataas.com/cat" alt="A cute cat">
+    <footer>
+        <ul class="footer-links">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Service</a></li>
+        </ul>
+    </footer>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Privacy Policy</h1>
+    <p>This page explains how we handle your data. We respect your privacy and do not collect personal information.</p>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -28,3 +28,25 @@ img {
     border-radius: 4px;
     padding: 5px;
 }
+
+footer {
+    text-align: center;
+    margin-top: 40px;
+    padding: 10px 0;
+    border-top: 1px solid #ccc;
+}
+
+.footer-links {
+    list-style: none;
+    padding: 0;
+}
+
+.footer-links li {
+    display: inline;
+    margin: 0 10px;
+}
+
+.footer-links a {
+    color: #333;
+    text-decoration: none;
+}

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Terms of Service</h1>
+    <p>By using this site you agree to our terms of service. Use the content at your own discretion.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add links for Privacy Policy and Terms of Service in a new footer
- create minimal Privacy Policy and Terms of Service pages
- style the footer and links

## Testing
- `tidy -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718e81905c832e980921da4ac63d15